### PR TITLE
Update trace_events_synth.c

### DIFF
--- a/kernel/trace/trace_events_synth.c
+++ b/kernel/trace/trace_events_synth.c
@@ -2023,7 +2023,8 @@ static int __synth_event_add_val(const char *field_name, u64 val,
 	if (trace_state->add_name) {
 		for (i = 0; i < event->n_fields; i++) {
 			field = event->fields[i];
-			if (strcmp(field->name, field_name) == 0)
+			/*if (strcmp(field->name, field_name) == 0)*/ /*SAM*/
+			if (field->name && field_name && strcmp(field->name, field_name) == 0)
 				break;
 		}
 		if (!field) {


### PR DESCRIPTION
comparison to null with no null value was identified . Fixed via provided check before strcomp